### PR TITLE
Use 'find -mtime' to process only the last emails.

### DIFF
--- a/mutt-alias.sh
+++ b/mutt-alias.sh
@@ -87,7 +87,13 @@ fi
 
 for directory in "$@"; do
   echo "Processing ${directory}"
-  for email in "$directory/"*; do
+  if [ "${max_age}" = "0" ]; then
+      emails="${directory}"/*
+  else
+      emails="$(find "${directory}" -type f -mtime "-${max_age}")"
+  fi
+
+  for email in $emails; do
     # Parse "To:"
     in_to="$(awk 'BEGIN {found="no"}; ((found=="yes") && /^\S/) || /^$/ {exit}; (found=="yes") && /^\s/ { printf "%s", $0 }; /^To:/ {found="yes"; sub(/^To: ?/, "", $0) ; printf "%s", $0}' "$email")"
 


### PR DESCRIPTION
The script works very well but unfortunately it takes a lot of time to process large mailboxes. Paying the cost once it is okay, but every time that the script runs is too expensive (and slow)
 
The '-d' option set a max old age for the new entries but it does not
prevent the script to read all the emails in the given mailboxes.

The proposed change is when '-d' is non-zero, use 'find -mtime' to filter any email older than
'n' days.
