### PR TITLE
Preserve IFS variable

### DIFF
--- a/mutt-alias.sh
+++ b/mutt-alias.sh
@@ -85,7 +85,10 @@ if [ "$purge" = true ]; then
   sed -Ei "/${alias_regexp}/d" "${alias_file}"
 fi
 
+old_IFS=$IFS
 for directory in "$@"; do
+  # Restore IFS
+  IFS=${old_IFS}
   echo "Processing ${directory}"
   for email in "$directory/"*; do
     # Parse "To:"
@@ -126,6 +129,9 @@ for directory in "$@"; do
     IFS=" "
   done
 done
+
+# Restore IFS
+IFS=${old_IFS}
 
 if perl -e 'use Encode::MIME::Header;' > /dev/null 2>&1; then
   perl -CS -MEncode -ne 'print decode("MIME-Header", $_)' \


### PR DESCRIPTION
The inner loop for email processing modifies the IFS variable to split
the text by comma and spaces but it never restores it to its original
setting.

Preserving IFS is needed so the rest of the script can work properly.